### PR TITLE
Handle trailing slash in server URL

### DIFF
--- a/lib/moddb.js
+++ b/lib/moddb.js
@@ -323,14 +323,14 @@ class ModDB {
         if (server.nexus !== undefined) {
             return Promise.resolve([]);
         }
-        const url = `${server.url}/by_name/${logicalName}/${versionMatch}`;
+        const url = `${server.url.endsWith('/') ? server.url : server.url + "/"}by_name/${logicalName}/${versionMatch}`;
         return this.restGet(url);
     }
     queryServerExpression(server, expression, versionMatch) {
         if (server.nexus !== undefined) {
             return Promise.resolve([]);
         }
-        const url = `${server.url}/by_expression/${expression}/${versionMatch}`;
+        const url = `${server.url.endsWith('/') ? server.url : server.url + "/"}/by_expression/${expression}/${versionMatch}`;
         return this.restGet(url);
     }
     queryServerHash(server, gameId, hash, size) {
@@ -361,7 +361,7 @@ class ModDB {
         });
     }
     queryServerHashMeta(server, hash) {
-        const url = `${server.url}/by_key/${hash}`;
+        const url = `${server.url.endsWith('/') ? server.url : server.url + "/"}/by_key/${hash}`;
         return this.restGet(url);
     }
     translateNexusGameId(input) {

--- a/src/moddb.ts
+++ b/src/moddb.ts
@@ -444,7 +444,7 @@ class ModDB {
       return Promise.resolve([]);
     }
 
-    const url = `${server.url}/by_name/${logicalName}/${versionMatch}`;
+    const url = `${server.url.endsWith('/') ? server.url : server.url + "/"}by_name/${logicalName}/${versionMatch}`;
     return this.restGet(url);
   }
 
@@ -455,7 +455,7 @@ class ModDB {
       return Promise.resolve([]);
     }
 
-    const url = `${server.url}/by_expression/${expression}/${versionMatch}`;
+    const url = `${server.url.endsWith('/') ? server.url : server.url + "/"}/by_expression/${expression}/${versionMatch}`;
     return this.restGet(url);
   }
 
@@ -490,7 +490,7 @@ class ModDB {
   }
 
   private queryServerHashMeta(server: IServer, hash: string): Promise<ILookupResult[]> {
-    const url = `${server.url}/by_key/${hash}`;
+    const url = `${server.url.endsWith('/') ? server.url : server.url + "/"}/by_key/${hash}`;
     return this.restGet(url);
   }
 


### PR DESCRIPTION
Currently if a server URL is passed to `create()` that has a trailing slash in the URL, it will cause lookups to fail since the final URL will include a double slash (i.e. `https://meta.server.com//by_key/`).

This should only append the leading slash to the path segments if the server URL doesn't already have a trailing slash.

---

I'm honestly not sure where this should be handled, since arguably the problem is that Vortex has no input sanitisation/checks of any kind when adding a metaserver, either through the UI or an extension. If you think this is better handled on the Vortex side (should just be a change to `ExtensionManager.getMetaServerList()`), let me know.