### PR TITLE
Wrap restGet Calls in Arrays

### DIFF
--- a/lib/moddb.js
+++ b/lib/moddb.js
@@ -458,14 +458,14 @@ class ModDB {
             return Promise.resolve([]);
         }
         const url = `${server.url.endsWith('/') ? server.url : server.url + "/"}by_name/${logicalName}/${versionMatch}`;
-        return this.restGet(url);
+        return [this.restGet(url)];
     }
     queryServerExpression(server, expression, versionMatch) {
         if (server.nexus !== undefined) {
             return Promise.resolve([]);
         }
         const url = `${server.url.endsWith('/') ? server.url : server.url + "/"}/by_expression/${expression}/${versionMatch}`;
-        return this.restGet(url);
+        return [this.restGet(url)];
     }
     queryServerHash(server, gameId, hash, size) {
         if (!isMD5Hash(hash)) {
@@ -486,7 +486,7 @@ class ModDB {
     }
     queryServerHashMeta(server, hash) {
         const url = `${server.url.endsWith('/') ? server.url : server.url + "/"}/by_key/${hash}`;
-        return this.restGet(url);
+        return [this.restGet(url)];
     }
     translateNexusGameId(input) {
         if ((input === 'skyrimse') || (input === 'skyrimvr')) {

--- a/src/moddb.ts
+++ b/src/moddb.ts
@@ -541,7 +541,7 @@ class ModDB {
     }
 
     const url = `${server.url.endsWith('/') ? server.url : server.url + "/"}by_name/${logicalName}/${versionMatch}`;
-    return this.restGet(url);
+    return [this.restGet(url)];
   }
 
   private queryServerExpression(server: IServer, expression: string,
@@ -552,7 +552,7 @@ class ModDB {
     }
 
     const url = `${server.url.endsWith('/') ? server.url : server.url + "/"}/by_expression/${expression}/${versionMatch}`;
-    return this.restGet(url);
+    return [this.restGet(url)];
   }
 
   private queryServerHash(server: IServer, gameId: string, hash: string, size: number): Promise<ILookupResult[]> {
@@ -577,7 +577,7 @@ class ModDB {
 
   private queryServerHashMeta(server: IServer, hash: string): Promise<ILookupResult[]> {
     const url = `${server.url.endsWith('/') ? server.url : server.url + "/"}/by_key/${hash}`;
-    return this.restGet(url);
+    return [this.restGet(url)];
   }
 
   private translateNexusGameId(input: string): string {


### PR DESCRIPTION
Without doing this, the server itself must wrap the JSON in brackets—which is not documented or intuitive—and, as an example of why this is required, Vortex throws an error attempting to parse the request without this (skipping the server and querying the next one).

Do note that using data from metadata servers throws other, more noticeable errors in Vortex at the moment. This is just the first domino.